### PR TITLE
Adding sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: elixir
 otp_release:
   - 17.4


### PR DESCRIPTION
Adding `sudo: false` to make running tests faster by using containers.
